### PR TITLE
Add interserction observer based inView hook for thumbs.

### DIFF
--- a/src/__tests__/components/Thumbnail.test.tsx
+++ b/src/__tests__/components/Thumbnail.test.tsx
@@ -36,7 +36,7 @@ describe('Thumbnail', function () {
         <Thumbnail item={canvas1 as Canvas} onClick={onClick} />
       </ReactContext.Provider>
     );
-    screen.getByTestId('thumbnail-wrapper').click();
+    screen.getByTestId('thumbnail-button').click();
     expect(onClick).toHaveBeenCalledWith(resource1.id);
   });
 

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -1,8 +1,9 @@
 import { Canvas, Collection, Manifest } from '@iiif/presentation-3';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { createThumbnailHelper } from '@iiif/vault-helpers';
 import { useThumbnailPanelContext } from '../context/IIIFResourceContext';
+import { useIsInView } from '../hooks/useIsInView';
 
 interface ThumbnailProps {
   item: Canvas | Collection | Manifest;
@@ -12,10 +13,16 @@ interface ThumbnailProps {
 export const Thumbnail: React.FC<ThumbnailProps> = ({ item, onClick }) => {
   const helper = createThumbnailHelper(); // no vault
   const [thumb, setThumb] = useState<any>();
+  const ref = useRef<HTMLDivElement>(null);
   const { resource } = useThumbnailPanelContext();
+  const isInView = useIsInView(ref);
   const thumbnailSize = (resource as any)?.thumbnailSize || 200;
 
   useEffect(() => {
+    if (isInView && item && !thumb) {
+      getData();
+    }
+
     async function getData() {
       const response = await helper.getBestThumbnailAtSize(item as any, {
         width: thumbnailSize,
@@ -23,36 +30,36 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({ item, onClick }) => {
       });
       setThumb(response.best as any);
     }
-
-    item && getData();
-  }, [item]);
+  }, [item, isInView]);
 
   return (
-    <button
-      data-testid="thumbnail-wrapper"
-      onClick={() => {
-        if (onClick) {
-          onClick(resource?.id);
-        }
-      }}
-    >
-      <figure>
-        <div
-          style={{
-            backgroundColor: '#f0f0f0',
-            width: `${thumbnailSize}px`,
-            height: `${thumbnailSize}px`,
-            objectFit: 'contain',
-          }}
-        >
-          {thumb ? (
-            <img src={thumb.id} alt="" style={{ maxWidth: '100%', maxHeight: '100%' }} data-testid="thumb-image" />
-          ) : (
-            <></>
-          )}
-        </div>
-        <figcaption>{item.id}</figcaption>
-      </figure>
-    </button>
+    <div data-testid="thumbnail-wrapper" ref={ref}>
+      <button
+        data-testid="thumbnail-button"
+        onClick={() => {
+          if (onClick) {
+            onClick(resource?.id);
+          }
+        }}
+      >
+        <figure>
+          <div
+            style={{
+              backgroundColor: '#f0f0f0',
+              width: `${thumbnailSize}px`,
+              height: `${thumbnailSize}px`,
+              objectFit: 'contain',
+            }}
+          >
+            {thumb ? (
+              <img src={thumb.id} alt="" style={{ maxWidth: '100%', maxHeight: '100%' }} data-testid="thumb-image" />
+            ) : (
+              <></>
+            )}
+          </div>
+          <figcaption>{item.id}</figcaption>
+        </figure>
+      </button>
+    </div>
   );
 };

--- a/src/hooks/useIsInView.ts
+++ b/src/hooks/useIsInView.ts
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+
+export const useIsInView = (ref: React.RefObject<HTMLElement | null>): boolean => {
+  const [isInView, setIsInView] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!('IntersectionObserver' in window)) {
+      console.warn('IntersectionObserver is not supported in this browser.');
+      setIsInView(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          setIsInView(entry.isIntersecting);
+          if (ref.current) {
+            observer.unobserve(ref.current);
+          }
+        });
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.1,
+      }
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, [ref]);
+
+  return isInView;
+};


### PR DESCRIPTION
## What does this do?

This adds a hand-rolled hook for detecting if an HTMLElement is within view of the browser window. It utilizes `IntersectionObserver` to observe this.

- The hook is called within each Thumbnail component and is used as a dependency for the `getData()` functionality that makes the info.json request that builds the rendered thumbnail. If `useIsInView` is true, two requests will be made for each thumbnail, (1) for the info.json and (2) for the rendered image of the <img/>.
- If IntersectionObvserver is not supported by a legacy browser, then this will always return true and lazy loading is effectively bypassed and all thumbnails are requested.

I decided for a manual implementation of this `IntersectionObserver` over available packages in order to not introduce additional dependencies to the component.

