### PR TITLE
Allow controlled / uncontrolled state for easier dev experience (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,87 @@ A consuming environment for developing is available via the `src/dev.tsx` compon
 
 ## Usage
 
-The app will export React components, and also a vanilla JavaScript bundled version.
+The app will export React components, and also a vanilla JavaScript bundled version (coming soon).
 
 ### Vanilla JavaScript
 
 ### React
 
-```jsx
+The `ThumbnailPanel` component can be used in a _controlled_ or _uncontrolled_ way. [What is controlled vs uncontrolled?](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+
+#### Controlled
+
+```tsx
 import { ThumbnailPanel } from "@iiif/thumbnail-panel";
+
+// Somewhere here you'll have to keep track of which
+// "resource" is "active".  Handle user events and
+// continually pass in whichever resourceId you want
+// to be active.
 
 ...
 <ThumbnailPanel
+    currentResourceId="someResourceId"
     iiifContent="https://iiif-commons.github.io/fixtures/examples/thumbnail_panel/non_paged_at_end/v2/manifest.json"
-    currentResourceId=""
+    onResourceChanged={(resourceId?: string) => {
+        console.log("resourceId", resourceId);
+        // Now you can pass around the current thumbnail item to
+        // other parts of your app which need to know about it.
+    }}
     orientation="vertical"
 />
 
 ```
 
+#### Uncontrolled
+
+```tsx
+import { ThumbnailPanel } from "@iiif/thumbnail-panel";
+
+function MyApp() {
+    ...
+
+    return (
+        <ThumbnailPanel
+            iiifContent="https://iiif-commons.github.io/fixtures/examples/thumbnail_panel/non_paged_at_end/v2/manifest.json"
+            onResourceChanged={(resourceId?: string) => console.log("resourceId", resourceId)}
+            orientation="vertical"
+        >
+            <Nav />
+        </ThumbnailPanel>
+    )
+}
+
+function Nav() {
+    const { isEnd, isStart, next, prev } = useThumbnailPanelContext();
+
+    const { handleNextClick, resourceId: nextResourceId } = next;
+    const { handlePrevClick, resourceId: prevResourceId } = prev;
+
+    return (
+        <>
+            <button onClick={handlePrevClick} disabled={isStart} data-id={prevResourceId}>
+                Prev
+            </button>
+            <button onClick={handleNextClick} disabled={isEnd} data-id={nextResourceId}>
+                Next
+            </button>
+        </>
+    );
+}
+
+```
+
+#### useThumbnailPanelContext()
+
+Helper hook, details coming soon...
+
 ## Publishing
+
 Checkout the `main` branch, and ensure it is up-to-date.
 
 Run `npm version [major | minor | patch]` for example:
+
 ```
 npm version patch
 ```

--- a/src/__tests__/components/Thumbnail.test.tsx
+++ b/src/__tests__/components/Thumbnail.test.tsx
@@ -2,21 +2,48 @@ import * as canvas1 from '../__fixtures__/canvas1.json';
 import * as canvasNoThumb from '../__fixtures__/canvas-no-thumb.json';
 import * as resource1 from '../__fixtures__/resource1.json';
 
+import { IIIFContentProvider, ReactContext } from '../../context/IIIFResourceContext';
 import { render, screen, waitFor } from '@testing-library/react';
 
 import { Canvas } from '@iiif/presentation-3';
+import { IIIFContentContext } from '../../context/IIIFResourceContext';
 import React from 'react';
-import { ReactContext } from '../../context/IIIFResourceContext';
 import { Thumbnail } from '../../components/Thumbnail';
 
+interface ProviderWrapperProps {
+  children: React.ReactNode;
+  initialState?: IIIFContentContext;
+}
+
 describe('Thumbnail', function () {
+  function ProviderWrapper({
+    children,
+    initialState = {
+      currentResourceId: '',
+      isControlled: true,
+      isLoaded: true,
+      orientation: 'vertical',
+      resource: resource1 as any,
+    },
+  }: ProviderWrapperProps) {
+    return <IIIFContentProvider initialState={initialState}>{children}</IIIFContentProvider>;
+  }
+
   it('should render the component', () => {
-    render(<Thumbnail item={canvas1 as Canvas} />);
+    render(
+      <ProviderWrapper>
+        <Thumbnail item={canvas1 as Canvas} />
+      </ProviderWrapper>
+    );
     expect(screen.getByTestId('thumbnail-wrapper')).toBeInTheDocument();
   });
 
   it('renders a thumbnail image', async () => {
-    render(<Thumbnail item={canvas1 as Canvas} />);
+    render(
+      <ProviderWrapper>
+        <Thumbnail item={canvas1 as Canvas} />
+      </ProviderWrapper>
+    );
     const el = await screen.findByTestId('thumb-image');
     expect(el).toBeInTheDocument();
   });
@@ -24,24 +51,20 @@ describe('Thumbnail', function () {
   it('calls the onClick handler when the thumbnail is clicked', () => {
     const onClick = vi.fn();
     render(
-      <ReactContext.Provider
-        value={{
-          resource: resource1 as any,
-          currentResourceId: '',
-          error: null,
-          isLoaded: true,
-          orientation: 'vertical',
-        }}
-      >
+      <ProviderWrapper>
         <Thumbnail item={canvas1 as Canvas} onClick={onClick} />
-      </ReactContext.Provider>
+      </ProviderWrapper>
     );
     screen.getByTestId('thumbnail-button').click();
     expect(onClick).toHaveBeenCalledWith(resource1.id);
   });
 
   it("renders only a placeholder if the thumbnail can't be found", async () => {
-    render(<Thumbnail item={canvasNoThumb as Canvas} />);
+    render(
+      <ProviderWrapper>
+        <Thumbnail item={canvasNoThumb as Canvas} />
+      </ProviderWrapper>
+    );
     await waitFor(() => {
       const el = screen.queryByTestId('thumb-image');
       expect(el).not.toBeInTheDocument();

--- a/src/components/Items.tsx
+++ b/src/components/Items.tsx
@@ -1,0 +1,97 @@
+import '../style.css';
+
+import React, { useMemo } from 'react';
+
+import { OnResourceChanged } from 'src/types/types';
+import { Thumbnail } from './Thumbnail';
+import { getValue } from '@iiif/vault-helpers';
+import { useThumbnailPanelContext } from '../context/IIIFResourceContext';
+
+interface ItemsProps {
+  onResourceChanged?: OnResourceChanged;
+}
+
+const Items: React.FC<ItemsProps> = ({ onResourceChanged }) => {
+  const {
+    dispatch,
+    state: { currentResourceId, isControlled, isLoaded, orientation, resource, sequences },
+  } = useThumbnailPanelContext();
+
+  if (!isLoaded || !resource || !sequences || !resource?.items) {
+    return <></>;
+  }
+
+  const dir = !resource.viewingDirection || resource.viewingDirection === 'left-to-right' ? 'ltr' : 'rtl';
+
+  const onKeyDown = (e: any) => {
+    if (e.keyCode === 40) {
+      const next = 1 + Number(e.currentTarget.getAttribute('data-index'));
+      `div[data-index="${next}"]`;
+      const nextElement = (e.currentTarget as HTMLDivElement).parentElement?.parentElement?.querySelector(
+        `div[data-index="${next}"]`
+      ) as HTMLElement;
+      nextElement.focus();
+    }
+  };
+
+  const isCurrentGroup = (groupIdx: number) => {
+    const foundIdx = sequences.findIndex((group) => {
+      const resourceIdx = resource.items.findIndex((resource) => {
+        return resource.id === currentResourceId;
+      });
+      return group.includes(resourceIdx);
+    });
+
+    return foundIdx === groupIdx;
+  };
+
+  const handleThumbClick = (resourceId: string) => {
+    if (onResourceChanged) {
+      onResourceChanged(resourceId);
+    }
+    if (isControlled) {
+      dispatch({ type: 'updateCurrentId', id: resourceId });
+    }
+  };
+
+  return (
+    <div dir={dir} thumbnail-panel="" data-orientation={orientation}>
+      <h3>{getValue(resource.label)}</h3>
+      <span>{orientation}</span>
+
+      {sequences.map((group, groupIdx) => {
+        // console.log('group', group);
+        return (
+          <div thumbnail-group="" key={groupIdx} data-selected={isCurrentGroup(groupIdx)}>
+            {group.map((idx, itemIdx) => (
+              <div
+                thumbnail-item=""
+                tabIndex={idx === 0 ? 0 : -1}
+                key={itemIdx}
+                data-index={idx}
+                onKeyDown={onKeyDown}
+                data-selected={currentResourceId === resource.items[idx]?.id}
+              >
+                <Thumbnail
+                  key={idx}
+                  item={resource.items[idx]}
+                  onClick={() => handleThumbClick(resource.items[idx]?.id)}
+                />
+              </div>
+            ))}
+          </div>
+        );
+      })}
+
+      {/* <p>{resource.behavior}</p>
+      <p>{resource.viewingDirection || 'left-to-right'}</p>
+      {resource?.items.map((item, index) => (
+        <>
+          <Thumbnail key={index} item={item} />
+        </>
+      ))} */}
+    </div>
+  );
+};
+
+export default Items;

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -2,8 +2,8 @@ import { Canvas, Collection, Manifest } from '@iiif/presentation-3';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { createThumbnailHelper } from '@iiif/vault-helpers';
-import { useThumbnailPanelContext } from '../context/IIIFResourceContext';
 import { useIsInView } from '../hooks/useIsInView';
+import { useThumbnailPanelContext } from '../context/IIIFResourceContext';
 
 interface ThumbnailProps {
   item: Canvas | Collection | Manifest;
@@ -14,7 +14,9 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({ item, onClick }) => {
   const helper = createThumbnailHelper(); // no vault
   const [thumb, setThumb] = useState<any>();
   const ref = useRef<HTMLDivElement>(null);
-  const { resource } = useThumbnailPanelContext();
+  const {
+    state: { resource },
+  } = useThumbnailPanelContext();
   const isInView = useIsInView(ref);
   const thumbnailSize = (resource as any)?.thumbnailSize || 200;
 
@@ -38,6 +40,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({ item, onClick }) => {
         data-testid="thumbnail-button"
         onClick={() => {
           if (onClick) {
+            console.log('resource.id', resource?.id);
             onClick(resource?.id);
           }
         }}

--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -1,141 +1,114 @@
 import '../style.css';
 
-import * as Presentation3 from '@iiif/presentation-3';
+import React, { useEffect, useState } from 'react';
 
 import { IIIFContentProvider, useThumbnailPanelContext } from '../context/IIIFResourceContext';
-import React, { useMemo } from 'react';
-
+import Items from './Items';
 import { Orientation } from 'src/types/options';
-import { Thumbnail } from './Thumbnail';
-import { createSequenceHelper } from '@iiif/vault-helpers/sequences';
-import { getValue } from '@iiif/vault-helpers';
-
-type OnResourceChanged = (resourceId?: string) => void;
-interface ItemsProps {
-  onResourceChanged?: OnResourceChanged;
-}
-
-const Items: React.FC<ItemsProps> = ({ onResourceChanged }) => {
-  const { resource, isLoaded, currentResourceId, orientation } = useThumbnailPanelContext();
-  const sequence = createSequenceHelper();
-
-  const [items, seq] = useMemo(() => {
-    if (!resource) {
-      return [];
-    }
-    //ignore type checking on resource (expecting ManifestNormalized)
-    //@ts-ignore
-    const [items, seq] = sequence.getManifestSequence(resource, {
-      disablePaging: false,
-    });
-
-    // if (resource.viewingDirection === 'bottom-to-top') {
-    //   return [items, seq.reverse()]
-    // }
-
-    return [items, seq];
-  }, [resource]);
-
-  if (!isLoaded || !resource || !seq || !items) {
-    return <></>;
-  }
-
-  const dir = resource.viewingDirection === 'left-to-right' ? 'ltr' : 'rtl';
-
-  const onKeyDown = (e: any) => {
-    if (e.keyCode === 40) {
-      const next = 1 + Number(e.currentTarget.getAttribute('data-index'));
-      `div[data-index="${next}"]`;
-      const nextElement = (e.currentTarget as HTMLDivElement).parentElement?.parentElement?.querySelector(
-        `div[data-index="${next}"]`
-      ) as HTMLElement;
-      nextElement.focus();
-    }
-  };
-
-  const isCurrentGroup = (groupIdx: number) => {
-    const foundIdx = seq.findIndex((group) => {
-      const resourceIdx = items.findIndex((resource) => {
-        return resource.id === currentResourceId;
-      });
-      return group.includes(resourceIdx);
-    });
-
-    return foundIdx === groupIdx;
-  };
-
-  return (
-    <div dir={dir} thumbnail-panel="" data-orientation={orientation}>
-      <h3>{getValue(resource.label)}</h3>
-      <span>{orientation}</span>
-
-      {seq.map((group, groupIdx) => {
-        // console.log('group', group);
-        return (
-          <div thumbnail-group="" key={groupIdx} data-selected={isCurrentGroup(groupIdx)}>
-            {group.map((idx, itemIdx) => (
-              <div
-                thumbnail-item=""
-                tabIndex={idx === 0 ? 0 : -1}
-                key={itemIdx}
-                data-index={idx}
-                onKeyDown={onKeyDown}
-                data-selected={currentResourceId === items[idx]?.id}
-              >
-                <Thumbnail
-                  key={idx}
-                  item={items[idx]}
-                  onClick={() => {
-                    // todo: set state
-                    if (onResourceChanged) {
-                      // console.log(idx);
-                      onResourceChanged(items[idx]?.id);
-                    }
-                  }}
-                />
-              </div>
-            ))}
-          </div>
-        );
-      })}
-
-      {/* <p>{resource.behavior}</p>
-      <p>{resource.viewingDirection || 'left-to-right'}</p>
-      {resource?.items.map((item, index) => (
-        <>
-          <Thumbnail key={index} item={item} />
-        </>
-      ))} */}
-    </div>
-  );
-};
+import { type OnResourceChanged, type Resource } from 'src/types/types';
+import { fetch } from '@iiif/vault-helpers/fetch';
 
 interface ThumbnailPanelProps {
-  currentResourceId?: string | undefined;
+  children?: React.ReactNode;
+  currentResourceId?: string;
   iiifContent: string;
   onLoad?: (resource: any) => void;
   onResourceChanged?: OnResourceChanged;
-  orientation?: Orientation;
-  overrides?: Partial<Presentation3.Collection | Presentation3.Manifest>;
+  orientation: Orientation;
+  overrides?: Partial<Resource>;
 }
 
 export const ThumbnailPanel: React.FC<ThumbnailPanelProps> = ({
-  iiifContent,
-  orientation,
+  children,
   currentResourceId,
-  overrides,
+  iiifContent,
   onLoad,
   onResourceChanged,
+  orientation = 'vertical',
+  overrides,
 }) => {
+  const [error, setError] = useState(false);
+  const [resource, setResource] = useState<Resource | undefined>();
+
+  useEffect(() => {
+    if (iiifContent) {
+      if (typeof iiifContent === 'string') {
+        const controller = new AbortController();
+
+        fetch(iiifContent, { signal: controller.signal })
+          .then((json) => {
+            setResource(json as any);
+            if (onLoad) {
+              onLoad(json);
+            }
+          })
+          .catch((e) => setError(e));
+
+        return () => {
+          controller.abort();
+        };
+      } else {
+        setResource(iiifContent);
+        if (onLoad) {
+          onLoad(iiifContent);
+        }
+      }
+    }
+  }, [iiifContent]);
+
   return (
     <IIIFContentProvider
-      resource={iiifContent}
-      overrides={overrides}
-      orientation={orientation || 'vertical'}
-      currentResourceId={currentResourceId}
-      onLoad={onLoad}
+      key={resource?.id}
+      initialState={{
+        currentResourceId: currentResourceId || '',
+        isControlled: !currentResourceId,
+        onResourceChanged,
+        orientation,
+        overrides,
+        resource,
+      }}
     >
-      <Items onResourceChanged={onResourceChanged} />
+      {/* {error && <p>Error: {error.message}</p>} */}
+      <ItemsWrapper currentResourceId={currentResourceId} orientation={orientation} overrides={overrides}>
+        <>
+          <Items onResourceChanged={onResourceChanged} />
+          {children}
+        </>
+      </ItemsWrapper>
     </IIIFContentProvider>
   );
 };
+
+interface ItemsWrapperProps {
+  children: React.ReactNode;
+  currentResourceId?: string;
+  orientation: Orientation;
+  overrides?: Partial<Resource>;
+}
+
+function ItemsWrapper({ children, currentResourceId, orientation, overrides }: ItemsWrapperProps) {
+  const { dispatch } = useThumbnailPanelContext();
+
+  useEffect(() => {
+    if (currentResourceId) {
+      dispatch({ type: 'updateCurrentId', id: currentResourceId });
+    }
+  }, [currentResourceId]);
+
+  useEffect(() => {
+    dispatch({
+      type: 'updateOrientation',
+      orientation,
+    });
+  }, [orientation]);
+
+  useEffect(() => {
+    if (overrides && Object.keys(overrides).length > 0) {
+      dispatch({
+        type: 'updateOverrides',
+        overrides,
+      });
+    }
+  }, [overrides]);
+  return <>{children}</>;
+}

--- a/src/context/IIIFResourceContext.tsx
+++ b/src/context/IIIFResourceContext.tsx
@@ -1,41 +1,126 @@
-import * as Presentation3 from '@iiif/presentation-3';
-
 import React, { ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react';
-
+import { getNavResourceItemId, isFirstResourceItem, isLastResourceItem } from '../lib/helpers';
 import { Orientation } from 'src/types/options';
-import { fetch } from '@iiif/vault-helpers/fetch';
+import { type OnResourceChanged, type Resource } from 'src/types/types';
+import { createSequenceHelper } from '@iiif/vault-helpers/sequences';
 
-interface IIIFContentContext {
-  currentResourceId: string | undefined;
-  error: string | any | null;
-  isLoaded: boolean;
+export interface IIIFContentContext {
+  currentResourceId: string;
+  isControlled: boolean;
+  isEnd?: boolean;
+  isLoaded?: boolean;
+  isStart?: boolean;
+  onResourceChanged?: OnResourceChanged;
   orientation: Orientation;
-  resource?: Presentation3.Manifest | Presentation3.Collection;
+  overrides?: Partial<Resource>;
+  resource?: Resource;
+  sequences?: number[][];
+}
+type Action =
+  | {
+      type: 'updateCurrentId';
+      id: string;
+    }
+  | {
+      type: 'updateOrientation';
+      orientation: Orientation;
+    }
+  | {
+      type: 'updateOverrides';
+      overrides: Partial<Resource>;
+    }
+  | {
+      type: 'updateSequences';
+      sequences: number[][];
+    };
+type Dispatch = (action: Action) => void;
+type State = IIIFContentContext;
+
+export interface IIIFContentProviderProps {
+  children: ReactNode;
+  initialState: {
+    currentResourceId: string;
+    isControlled: boolean;
+    isLoaded?: boolean;
+    onResourceChanged?: OnResourceChanged;
+    orientation: Orientation;
+    overrides?: Partial<Resource>;
+    resource?: Resource;
+  };
 }
 
-export const ReactContext = createContext<IIIFContentContext>({
-  currentResourceId: undefined,
-  error: null,
+const defaultState: IIIFContentContext = {
+  currentResourceId: '',
+  isControlled: true,
+  isEnd: false,
   isLoaded: false,
+  isStart: true,
   orientation: 'vertical',
   resource: undefined,
-});
+  sequences: [],
+};
 
-export function useThumbnailPanelContext() {
-  return useContext(ReactContext);
+const ReactContext = createContext<
+  | {
+      state: State;
+      dispatch: Dispatch;
+      next: {
+        resourceId: string | undefined;
+        handleNextClick: () => void;
+      };
+      prev: {
+        resourceId: string | undefined;
+        handlePrevClick: () => void;
+      };
+    }
+  | undefined
+>(undefined);
+
+function useThumbnailPanelContext() {
+  const context = useContext(ReactContext);
+  if (context === undefined) {
+    throw new Error('useThumbnailPanelContext must be used within a IIIFContentProvider');
+  }
+  return context;
 }
 
-export function IIIFContentProvider(props: {
-  resource: string | any;
-  children: ReactNode;
-  overrides?: Partial<Presentation3.Manifest | Presentation3.Collection>;
-  currentResourceId: string | undefined;
-  orientation: Orientation;
-  onLoad?: (resource?: Presentation3.Manifest | Presentation3.Collection) => void;
-  onResourceChanged?: (resourceId: string) => void;
-}) {
-  const { currentResourceId, orientation, onLoad, overrides } = props;
-  const [resource, setResource] = useState<Presentation3.Manifest | Presentation3.Collection>();
+/** Handle updates to Context state here */
+function reducer(state: State, action: Action) {
+  switch (action.type) {
+    case 'updateCurrentId': {
+      return {
+        ...state,
+        currentResourceId: action.id,
+      };
+    }
+    case 'updateOrientation': {
+      return {
+        ...state,
+        orientation: action.orientation,
+      };
+    }
+    case 'updateOverrides': {
+      return {
+        ...state,
+        overrides: { ...action.overrides },
+      };
+    }
+    case 'updateSequences': {
+      return {
+        ...state,
+        sequences: action.sequences,
+      };
+    }
+    default: {
+      throw new Error(`Unhandled action type`);
+    }
+  }
+}
+
+function IIIFContentProvider({ initialState = defaultState, children }: IIIFContentProviderProps) {
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const { currentResourceId, isControlled, onResourceChanged, overrides, resource, sequences } = state;
+
   const mergedResource = useMemo(() => {
     if (!overrides || !resource) {
       return resource;
@@ -45,39 +130,100 @@ export function IIIFContentProvider(props: {
 
     return Object.assign({}, resource, values || {});
   }, [resource, ...Object.values(overrides || {})]);
-  const [error, setError] = useState(false);
 
   useEffect(() => {
-    if (!props.resource) {
-      return;
-    }
+    if (resource && isControlled) {
+      const sequence = createSequenceHelper();
+      // @ts-ignore
+      const [items, resourceSequences] = sequence.getManifestSequence(resource, {
+        disablePaging: false,
+      });
 
-    if (typeof props.resource === 'string') {
-      const controller = new AbortController();
+      dispatch({
+        type: 'updateSequences',
+        sequences: resourceSequences,
+      });
 
-      fetch(props.resource, { signal: controller.signal })
-        .then((json) => {
-          setResource(json as any);
-          if (onLoad) {
-            onLoad(json);
-          }
-        })
-        .catch((e) => setError(e));
+      if (isControlled) {
+        const id = resource.items[0].id;
 
-      return () => {
-        controller.abort();
-      };
-    } else {
-      setResource(props.resource);
-      if (onLoad) {
-        onLoad(props.resource);
+        // Pass back the first resource id on load
+        onResourceChanged && onResourceChanged(id);
+
+        // If current resource id is controlled, update context
+        dispatch({
+          type: 'updateCurrentId',
+          id,
+        });
       }
     }
-  }, [props.resource]);
+  }, [resource]);
 
-  const value = useMemo(() => {
-    return { resource: mergedResource, error, isLoaded: !!resource, orientation, currentResourceId };
-  }, [mergedResource, error, orientation, currentResourceId]);
+  useEffect(() => {
+    if (currentResourceId && onResourceChanged) {
+      onResourceChanged(currentResourceId);
+    }
+  }, [currentResourceId]);
 
-  return <ReactContext.Provider value={value}>{props.children}</ReactContext.Provider>;
+  const next = () => {
+    const nextResourceId = getNavResourceItemId({
+      currentResourceId,
+      direction: 'next',
+      resource,
+      sequences,
+    });
+
+    nextResourceId &&
+      dispatch({
+        type: 'updateCurrentId',
+        id: nextResourceId,
+      });
+  };
+
+  const prev = () => {
+    const prevResourceId = getNavResourceItemId({
+      currentResourceId,
+      direction: 'prev',
+      resource,
+      sequences,
+    });
+    prevResourceId &&
+      dispatch({
+        type: 'updateCurrentId',
+        id: prevResourceId,
+      });
+  };
+
+  const value = {
+    state: {
+      ...state,
+      isLoaded: !!resource,
+      isEnd: isLastResourceItem(state.currentResourceId, state.resource),
+      isStart: isFirstResourceItem(state.currentResourceId, state.resource),
+      resource: mergedResource,
+    },
+    dispatch,
+    next: {
+      resourceId: getNavResourceItemId({
+        currentResourceId,
+        direction: 'next',
+        resource,
+        sequences,
+      }),
+      handleNextClick: next,
+    },
+    prev: {
+      resourceId: getNavResourceItemId({
+        currentResourceId,
+        direction: 'prev',
+        resource,
+        sequences,
+      }),
+      handlePrevClick: prev,
+    },
+  };
+
+  return <ReactContext.Provider value={value}>{children}</ReactContext.Provider>;
 }
+
+export { IIIFContentProvider, ReactContext, useThumbnailPanelContext };

--- a/src/dev-uncontrolled.tsx
+++ b/src/dev-uncontrolled.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ThumbnailPanel } from './index';
+import { useState } from 'react';
+import { useThumbnailPanelContext } from './context/IIIFResourceContext';
+
+const Wrapper = () => {
+  const url = new URL(window.location.href);
+  const contentState = url.searchParams.get('iiif-content');
+  const [currentId, setCurrentId] = useState<string | undefined>('');
+
+  return (
+    <>
+      <div
+        style={{
+          background: '#333',
+          color: 'white',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: '1rem',
+        }}
+      >
+        <h2>Viewer</h2>
+        <dl>
+          <dt>Current Resource ID:</dt>
+          <dd>{currentId}</dd>
+        </dl>
+      </div>
+      <ThumbnailPanel
+        iiifContent={
+          contentState ||
+          `https://iiif-commons.github.io/fixtures/examples/thumbnail_panel/non_paged_at_end/v2/manifest.json`
+        }
+        orientation={`vertical`}
+        onResourceChanged={(resourceId?: string) => {
+          setCurrentId(resourceId);
+        }}
+      >
+        <NavWrapperTest />
+      </ThumbnailPanel>
+    </>
+  );
+};
+
+function NavWrapperTest() {
+  const {
+    next,
+    prev,
+    state: { isEnd, isStart },
+  } = useThumbnailPanelContext();
+
+  const { handleNextClick, resourceId: nextResourceId } = next;
+  const { handlePrevClick, resourceId: prevResourceId } = prev;
+
+  return (
+    <>
+      <button onClick={handlePrevClick} disabled={isStart} data-id={prevResourceId}>
+        Prev
+      </button>
+      <button onClick={handleNextClick} disabled={isEnd} data-id={nextResourceId}>
+        Next
+      </button>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Wrapper />
+  </React.StrictMode>
+);

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -73,6 +73,7 @@ const Wrapper = () => {
     const currentResourceIndex = resource.items.findIndex((item) => {
       return item.id === currentResourceId;
     });
+    console.log('currentResourceIndex', currentResourceIndex);
 
     if (currentResourceIndex > 0) {
       prevResourceId = resource.items[currentResourceIndex - 1].id;
@@ -93,6 +94,7 @@ const Wrapper = () => {
     const currentResourceIndex = resource.items.findIndex((item) => {
       return item.id === currentResourceId;
     });
+    console.log('currentResourceIndex', currentResourceIndex);
 
     if (currentResourceIndex !== -1 && currentResourceIndex !== resource.items.length - 1) {
       nextResourceId = resource.items[currentResourceIndex + 1].id;
@@ -124,7 +126,6 @@ const Wrapper = () => {
         currentResourceId={currentResourceId}
         orientation={orientation as Orientation}
         onResourceChanged={(resourceId?: string) => {
-          // console.log(resourceId);
           setIIIFContent({
             currentResourceId: resourceId,
           });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export * from './components/Thumbnail';
 export * from './components/ThumbnailPanel';
+export * from './lib/helpers';

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,63 @@
+import { Resource } from 'src/types/types';
+
+type GuardedResource = Resource | undefined;
+type GuardedSequences = number[][] | undefined;
+
+const isFirstResourceItem = (currentResourceId: string, resource: GuardedResource): boolean | undefined => {
+  if (!resource || !currentResourceId) {
+    return;
+  }
+  const currentResourceIndex = getResourceItemIndex(currentResourceId, resource);
+  return currentResourceIndex > -1 ? currentResourceIndex === 0 : undefined;
+};
+
+const isLastResourceItem = (currentResourceId: string, resource: GuardedResource): boolean | undefined => {
+  if (!resource || !currentResourceId) {
+    return;
+  }
+  const currentResourceIndex = getResourceItemIndex(currentResourceId, resource);
+  return currentResourceIndex > -1 ? currentResourceIndex === resource.items.length - 1 : undefined;
+};
+
+const getResourceItemIndex = (currentResourceId: string, resource: GuardedResource) => {
+  if (!resource || !currentResourceId) {
+    return -1;
+  }
+  const currentResourceIndex = resource.items.findIndex((item) => {
+    return item.id === currentResourceId;
+  });
+  return currentResourceIndex;
+};
+
+const getNavResourceItemId = ({
+  currentResourceId,
+  direction,
+  resource,
+  sequences,
+}: {
+  currentResourceId: string;
+  direction: 'next' | 'prev';
+  resource: GuardedResource;
+  sequences: GuardedSequences;
+}) => {
+  if (!currentResourceId || !resource || !sequences) {
+    return;
+  }
+
+  const sequencesIdx = sequences.findIndex((group) => {
+    const currentResourceIndex = getResourceItemIndex(currentResourceId, resource);
+    return group.includes(currentResourceIndex);
+  });
+
+  if (direction === 'next' && sequencesIdx === sequences.length - 1) {
+    return;
+  }
+  if (direction === 'prev' && sequencesIdx === 0) {
+    return;
+  }
+
+  const resourceId = resource.items[sequences[direction === 'next' ? sequencesIdx + 1 : sequencesIdx - 1][0]].id;
+  return resourceId;
+};
+
+export { getNavResourceItemId, getResourceItemIndex, isFirstResourceItem, isLastResourceItem };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,4 @@
+import * as Presentation3 from '@iiif/presentation-3';
+
+export type OnResourceChanged = (resourceId: string) => void;
+export type Resource = Presentation3.Manifest | Presentation3.Collection;


### PR DESCRIPTION
## What does this do?
This tests a "basic" user implementation who might want to let the `ThumbnailPanel` component handle some state internally (*uncontrolled*). The general idea is if the user passes `currentResourceId` to the component, then managing state of the Thumbnail Panel active items will be *controlled* by the Parent.  If `currentResourceId` is not provided, then `ThumbnailPanel` will act as *uncontrolled* and maintain state internally. 

[What is controlled vs uncontrolled?](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components)

## Specific changes

- Includes a new dev environment to test basic implementation not knowing about `Leva`.
  - To test this, change the `index.html` file on line 11 to this: `<script type="module" src="/src/dev-uncontrolled.tsx"></script>`
- Tries to thin out / clean up what's stored parent, top-level `Context`.
- Introduces `useReducer` pattern for maintaining `Context` state and `dispatch` updates (in case the user config grows to a large and somewhat complex object).
- Expands `Context`, and the `useThumbnailPanelContext()` hook to export `next` and `prev` objects for user's ease of implementation their own navigation.
- Adds `boolean` `isEnd` and `isStart` convenience helpers to `useThumbnailPanelContext()`.
- Exports all the helpers in `/lib/helpers.ts` as vanilla JavaScript modules (if a controlled version would like to not code all the logic themselves).

## How to test
Try this out in both the `dev.tsx` and `dev-uncontrolled.tsx`environments.  Or better yet, any React app, Codesandbox, etc.

Curious on others thoughts on how this may or may not play out for a wide range of dev experience use cases.  I have no idea how this would play out in a non-React environment.  Would have to test that once one is in place.