### PR TITLE
Fix changing behavior override

### DIFF
--- a/src/components/ThumbnailPanel.tsx
+++ b/src/components/ThumbnailPanel.tsx
@@ -6,7 +6,6 @@ import Items from './Items';
 import { Orientation } from 'src/types/options';
 import { type OnResourceChanged, type Resource } from 'src/types/types';
 import { fetch } from '@iiif/vault-helpers/fetch';
-import { createSequenceHelper } from '@iiif/vault-helpers/sequences';
 
 interface ThumbnailPanelProps {
   children?: React.ReactNode;
@@ -14,7 +13,7 @@ interface ThumbnailPanelProps {
   iiifContent: string;
   onLoad?: (resource: any) => void;
   onResourceChanged?: OnResourceChanged;
-  orientation: Orientation;
+  orientation?: Orientation;
   overrides?: Partial<Resource>;
 }
 
@@ -47,25 +46,17 @@ export const ThumbnailPanel: React.FC<ThumbnailPanelProps> = ({
 
     fetch(iiifContent, { signal: controller.signal })
       .then((json) => {
-        // Create sequences to help group resource items
-        const sequence = createSequenceHelper();
-        // @ts-ignore
-        const [, sequences] = sequence.getManifestSequence(json, {
-          disablePaging: false,
-        });
-
         // Update Context with ThumbnailPanel config props
         dispatch({
           type: 'initialize',
           payload: {
-            currentResourceId,
+            currentResourceId: currentResourceId || '',
             isControlled: !!currentResourceId,
             isLoaded: true,
             onResourceChanged,
             resource: json,
             orientation,
             overrides,
-            sequences,
           },
         });
         if (onLoad) {

--- a/src/context/IIIFResourceContext.tsx
+++ b/src/context/IIIFResourceContext.tsx
@@ -1,17 +1,22 @@
-import React, { ReactNode, createContext, useCallback, useContext, useEffect, useMemo } from 'react';
-import { getResourceItemIndex, isFirstResourceItem, isLastResourceItem } from '../lib/helpers';
+import React, { ReactNode, createContext, useCallback, useContext, useEffect } from 'react';
+import {
+  getResourceItemIndex,
+  isFirstResourceItem,
+  isLastResourceItem,
+  mergeOverridesWithResource,
+} from '../lib/helpers';
 import { Orientation } from 'src/types/options';
-import { type OnResourceChanged, type Resource } from 'src/types/types';
+import { Sequences, type OnResourceChanged, type Resource } from 'src/types/types';
+import { createSequenceHelper } from '@iiif/vault-helpers/sequences';
+
+type GetNavIdArgs = {
+  currentResourceId: string;
+  direction: 'next' | 'prev';
+};
 
 export interface IIIFContentContext {
-  currentResourceId?: string;
-  getNavId?: ({
-    currentResourceId,
-    direction,
-  }: {
-    currentResourceId: string;
-    direction: 'next' | 'prev';
-  }) => string | undefined;
+  currentResourceId: string;
+  getNavId?: ({ currentResourceId, direction }: GetNavIdArgs) => string | undefined;
   isControlled?: boolean;
   isEnd?: boolean;
   isLoaded?: boolean;
@@ -25,15 +30,15 @@ export interface IIIFContentContext {
     handlePrevClick: () => void;
   };
   onResourceChanged?: OnResourceChanged;
-  orientation?: Orientation;
+  orientation: Orientation;
   overrides?: Partial<Resource>;
   resource?: Resource | undefined;
-  sequences?: number[][];
+  sequences?: Sequences;
 }
 type Action =
   | {
       type: 'initialize';
-      payload: Partial<IIIFContentContext>;
+      payload: IIIFContentContext;
     }
   | {
       type: 'updateCurrentId';
@@ -46,27 +51,14 @@ type Action =
   | {
       type: 'updateOverrides';
       overrides: Partial<Resource>;
-    }
-  | {
-      type: 'updateSequences';
-      sequences: number[][];
     };
 type Dispatch = (action: Action) => void;
 type State = IIIFContentContext;
 
 export interface IIIFContentProviderProps {
   children: ReactNode;
-  initialState?: Partial<IIIFContentContext>;
+  initialState?: IIIFContentContext;
 }
-
-const defaultState: IIIFContentContext = {
-  currentResourceId: '',
-  isEnd: false,
-  isLoaded: false,
-  isStart: true,
-  orientation: 'vertical',
-  sequences: [],
-};
 
 const ReactContext = createContext<
   | {
@@ -76,11 +68,29 @@ const ReactContext = createContext<
   | undefined
 >(undefined);
 
+const sequenceHelper = createSequenceHelper();
+
 /** Handle updates to Context state here */
 function reducer(state: State, action: Action) {
   switch (action.type) {
     case 'initialize': {
-      return action.payload;
+      // Merge overrides with the Manifest/Canvas
+      const mergedResource = mergeOverridesWithResource({
+        resource: action.payload.resource,
+        overrides: action.payload.overrides,
+      });
+
+      // Get updated sequences
+      // @ts-ignore
+      const [, sequences] = sequenceHelper.getManifestSequence(mergedResource, {
+        disablePaging: false,
+      });
+
+      return {
+        ...action.payload,
+        resource: mergedResource,
+        sequences,
+      };
     }
     case 'updateCurrentId': {
       return {
@@ -95,15 +105,21 @@ function reducer(state: State, action: Action) {
       };
     }
     case 'updateOverrides': {
+      const mergedResource = mergeOverridesWithResource({
+        resource: state.resource,
+        overrides: action.overrides,
+      });
+
+      // @ts-ignore
+      const [, sequences] = sequenceHelper.getManifestSequence(mergedResource, {
+        disablePaging: false,
+      });
+
       return {
         ...state,
         overrides: { ...action.overrides },
-      };
-    }
-    case 'updateSequences': {
-      return {
-        ...state,
-        sequences: action.sequences,
+        resource: mergedResource,
+        sequences,
       };
     }
     default: {
@@ -112,25 +128,17 @@ function reducer(state: State, action: Action) {
   }
 }
 
+const defaultState: IIIFContentContext = {
+  currentResourceId: '',
+  isEnd: false,
+  isLoaded: false,
+  isStart: true,
+  orientation: 'vertical',
+};
+
 function IIIFContentProvider({ initialState = defaultState, children }: IIIFContentProviderProps) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const { currentResourceId, isControlled, onResourceChanged, overrides, resource, sequences } = state;
-
-  // const mergedResource = useMemo(() => {
-  //   if (!overrides || !resource) {
-  //     return resource;
-  //   }
-
-  //   const values = Object.fromEntries(Object.entries(overrides).filter(([, value]) => typeof value !== 'undefined'));
-
-  //   return Object.assign({}, resource, values || {});
-  // }, [resource, ...Object.values(overrides || {})]);
-
-  let mergedResource = resource;
-  if (overrides && resource) {
-    const values = Object.fromEntries(Object.entries(overrides).filter(([, value]) => typeof value !== 'undefined'));
-    mergedResource = Object.assign({}, resource, values || {});
-  }
 
   useEffect(() => {
     if (resource && !isControlled) {
@@ -203,7 +211,7 @@ function IIIFContentProvider({ initialState = defaultState, children }: IIIFCont
   };
 
   const getNavId = useCallback(
-    ({ currentResourceId, direction }: { currentResourceId?: string; direction: 'next' | 'prev' }) => {
+    ({ currentResourceId, direction }: GetNavIdArgs) => {
       if (!currentResourceId || !resource || !sequences) {
         return;
       }
@@ -252,7 +260,6 @@ function IIIFContentProvider({ initialState = defaultState, children }: IIIFCont
         }),
         handlePrevClick: prev,
       },
-      resource: mergedResource,
     },
     dispatch,
   };

--- a/src/context/IIIFResourceContext.tsx
+++ b/src/context/IIIFResourceContext.tsx
@@ -1,5 +1,10 @@
 import React, { ReactNode, createContext, useCallback, useContext, useEffect } from 'react';
-import { getIdInSequence, isFirstResourceItem, isLastResourceItem, mergeOverridesWithResource } from '../lib/helpers';
+import {
+  getIdInSequence,
+  getMergedResourceAndSequences,
+  isFirstResourceItem,
+  isLastResourceItem,
+} from '../lib/helpers';
 import { Orientation } from 'src/types/options';
 import { Sequences, type OnResourceChanged, type Resource } from 'src/types/types';
 import { createSequenceHelper } from '@iiif/vault-helpers/sequences';
@@ -69,16 +74,9 @@ const sequenceHelper = createSequenceHelper();
 function reducer(state: State, action: Action) {
   switch (action.type) {
     case 'initialize': {
-      // Merge overrides with the Manifest/Canvas
-      const mergedResource = mergeOverridesWithResource({
+      const { mergedResource, sequences } = getMergedResourceAndSequences({
         resource: action.payload.resource,
         overrides: action.payload.overrides,
-      });
-
-      // Get updated sequences
-      // @ts-ignore
-      const [, sequences] = sequenceHelper.getManifestSequence(mergedResource, {
-        disablePaging: false,
       });
 
       return {
@@ -100,14 +98,10 @@ function reducer(state: State, action: Action) {
       };
     }
     case 'updateOverrides': {
-      const mergedResource = mergeOverridesWithResource({
+      console.log('action.overrides', action.overrides);
+      const { mergedResource, sequences } = getMergedResourceAndSequences({
         resource: state.resource,
         overrides: action.overrides,
-      });
-
-      // @ts-ignore
-      const [, sequences] = sequenceHelper.getManifestSequence(mergedResource, {
-        disablePaging: false,
       });
 
       return {

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 const Wrapper = () => {
   const url = new URL(window.location.href);
   const contentState = url.searchParams.get('iiif-content');
-  const { dispatch } = useThumbnailPanelContext();
+  const { dispatch, state } = useThumbnailPanelContext();
 
   const options = {
     ...(contentState && { 'iiif-content': contentState }),
@@ -86,10 +86,12 @@ const Wrapper = () => {
   }, [orientation]);
 
   useEffect(() => {
-    dispatch({
-      type: 'updateOverrides',
-      overrides: overrides as any,
-    });
+    if (state.resource) {
+      dispatch({
+        type: 'updateOverrides',
+        overrides: overrides as any,
+      });
+    }
   }, [overrides.behavior, overrides.viewingDirection, overrides.thumbnailSize]);
 
   const handleNavClick = (direction: 'next' | 'previous') => {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -29,4 +29,21 @@ const getResourceItemIndex = (currentResourceId: string, resource: GuardedResour
   return currentResourceIndex;
 };
 
-export { getResourceItemIndex, isFirstResourceItem, isLastResourceItem };
+const mergeOverridesWithResource = ({ resource, overrides }: { resource: GuardedResource; overrides: any }) => {
+  let mergedResource = resource;
+
+  if (!resource) {
+    return;
+  }
+  if (!overrides) {
+    return resource;
+  }
+
+  if (overrides && resource) {
+    const values = Object.fromEntries(Object.entries(overrides).filter(([, value]) => typeof value !== 'undefined'));
+    mergedResource = Object.assign({}, resource, values || {});
+  }
+  return mergedResource;
+};
+
+export { getResourceItemIndex, isFirstResourceItem, isLastResourceItem, mergeOverridesWithResource };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,7 +1,11 @@
 import { Resource, Sequences } from 'src/types/types';
 
+import { createSequenceHelper } from '@iiif/vault-helpers/sequences';
+
 type GuardedResource = Resource | undefined;
 type GuardedSequences = number[][] | undefined;
+
+const sequenceHelper = createSequenceHelper();
 
 const getIdInSequence = ({
   currentResourceId,
@@ -33,6 +37,30 @@ const getIdInSequence = ({
   } catch (e) {
     return '';
   }
+};
+
+const getMergedResourceAndSequences = ({
+  resource,
+  overrides,
+}: {
+  resource: Resource | undefined;
+  overrides: Partial<Resource> | undefined;
+}) => {
+  // Merge overrides with the Manifest/Canvas
+  const mergedResource = !overrides
+    ? resource
+    : mergeOverridesWithResource({
+        resource,
+        overrides,
+      });
+
+  // Get updated sequences
+  // @ts-ignore
+  const [, sequences] = sequenceHelper.getManifestSequence(mergedResource, {
+    disablePaging: false,
+  });
+
+  return { mergedResource, sequences };
 };
 
 const getResourceItemIndex = (currentResourceId: string, resource: GuardedResource) => {
@@ -78,4 +106,11 @@ const mergeOverridesWithResource = ({ resource, overrides }: { resource: Guarded
   return mergedResource;
 };
 
-export { getIdInSequence, getResourceItemIndex, isFirstResourceItem, isLastResourceItem, mergeOverridesWithResource };
+export {
+  getIdInSequence,
+  getMergedResourceAndSequences,
+  getResourceItemIndex,
+  isFirstResourceItem,
+  isLastResourceItem,
+  mergeOverridesWithResource,
+};

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,7 +1,49 @@
-import { Resource } from 'src/types/types';
+import { Resource, Sequences } from 'src/types/types';
 
 type GuardedResource = Resource | undefined;
 type GuardedSequences = number[][] | undefined;
+
+const getIdInSequence = ({
+  currentResourceId,
+  direction,
+  resource,
+  sequences,
+}: {
+  currentResourceId: string;
+  direction: 'next' | 'prev';
+  resource: Resource;
+  sequences: Sequences;
+}) => {
+  const sequencesIdx = sequences.findIndex((group) => {
+    const currentResourceIndex = getResourceItemIndex(currentResourceId, resource);
+    return group.includes(currentResourceIndex);
+  });
+
+  if (direction === 'next' && sequencesIdx === sequences.length - 1) {
+    return;
+  }
+  if (direction === 'prev' && sequencesIdx === 0) {
+    return;
+  }
+
+  try {
+    const sequenceIndex = sequences[direction === 'next' ? sequencesIdx + 1 : sequencesIdx - 1][0];
+    const resourceId = resource.items[sequenceIndex].id;
+    return resourceId;
+  } catch (e) {
+    return '';
+  }
+};
+
+const getResourceItemIndex = (currentResourceId: string, resource: GuardedResource) => {
+  if (!resource || !currentResourceId) {
+    return -1;
+  }
+  const currentResourceIndex = resource.items.findIndex((item) => {
+    return item.id === currentResourceId;
+  });
+  return currentResourceIndex;
+};
 
 const isFirstResourceItem = (currentResourceId: string, resource: GuardedResource): boolean | undefined => {
   if (!resource || !currentResourceId) {
@@ -17,16 +59,6 @@ const isLastResourceItem = (currentResourceId: string, resource: GuardedResource
   }
   const currentResourceIndex = getResourceItemIndex(currentResourceId, resource);
   return currentResourceIndex > -1 ? currentResourceIndex === resource.items.length - 1 : undefined;
-};
-
-const getResourceItemIndex = (currentResourceId: string, resource: GuardedResource) => {
-  if (!resource || !currentResourceId) {
-    return -1;
-  }
-  const currentResourceIndex = resource.items.findIndex((item) => {
-    return item.id === currentResourceId;
-  });
-  return currentResourceIndex;
 };
 
 const mergeOverridesWithResource = ({ resource, overrides }: { resource: GuardedResource; overrides: any }) => {
@@ -46,4 +78,4 @@ const mergeOverridesWithResource = ({ resource, overrides }: { resource: Guarded
   return mergedResource;
 };
 
-export { getResourceItemIndex, isFirstResourceItem, isLastResourceItem, mergeOverridesWithResource };
+export { getIdInSequence, getResourceItemIndex, isFirstResourceItem, isLastResourceItem, mergeOverridesWithResource };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -9,3 +9,5 @@ export type ResourceIds = {
   next: string | undefined;
   previous: string | undefined;
 };
+
+export type Sequences = number[][];


### PR DESCRIPTION
## What does this do?
The layout of thumbnails is determined in part, by Manifest `overrides`.  Somewhere along the line this got knocked loose.  This PR fixes changes in `behavior` under overrides.

